### PR TITLE
[Fix] issue #52: exclude revision when checking version

### DIFF
--- a/communote/commons/src/main/java/com/communote/common/util/VersionComparator.java
+++ b/communote/commons/src/main/java/com/communote/common/util/VersionComparator.java
@@ -7,7 +7,8 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.math.NumberUtils;
 
 /**
- * Comparator to compare versions, which contain a major, minor and optional a revision part.<br>
+ * Comparator to compare versions in dot notation like 3.25.2 as used in semantic versioning. The
+ * last part can be interpreted as revision.<br>
  * Examples
  * <ul>
  * <li>compare(1.0, 1.0.1) returns a value &lt; 0</li>
@@ -20,23 +21,30 @@ import org.apache.commons.lang.math.NumberUtils;
  */
 public class VersionComparator implements Comparator<String> {
 
-    private boolean includesRevision;
+    private boolean versionEndsWithRevision;
+    private boolean numericIncreasingRevision;
 
     /**
-     * Default Constructor
+     * Default constructor which creates a comparator that is not revision aware.
      */
     public VersionComparator() {
         // Do nothing.
     }
 
     /**
-     * Constructor to use revisions for the version comparison
+     * Constructor to fine-tune the handling of a revision in the version string
      *
-     * @param includesRevision
-     *            If true, the last part is the revision and the version number will be normalized.
+     * @param versionEndsWithRevision
+     *            If true, the last part of the version is always interpreted as revision
+     * @param numericIncreasingRevision 
+     *            if versionEndsWithRevision is true, this parameter defines whether the revision
+     *            is a numeric value which increases with every new revision. Only in this case
+     *            the revision is compared. 
+     *            
      */
-    public VersionComparator(boolean includesRevision) {
-        this.includesRevision = includesRevision;
+    public VersionComparator(boolean versionEndsWithRevision, boolean numericIncreasingRevision) {
+        this.versionEndsWithRevision = versionEndsWithRevision;
+        this.numericIncreasingRevision = numericIncreasingRevision;
     }
 
     /**
@@ -56,7 +64,7 @@ public class VersionComparator implements Comparator<String> {
         Object[] v2 = version2.split("\\.");
         Object revisionV1 = null;
         Object revisionV2 = null;
-        if (includesRevision) {
+        if (versionEndsWithRevision) {
             revisionV1 = v1[v1.length - 1];
             revisionV2 = v2[v2.length - 1];
             v1 = ArrayUtils.remove(v1, v1.length - 1);
@@ -71,9 +79,7 @@ public class VersionComparator implements Comparator<String> {
                 v1 = ArrayUtils.addAll(v1, filler);
             }
         }
-        // KENMEI-6778 Only add revision again, if it is numeric
-        if (includesRevision && NumberUtils.isDigits(revisionV1.toString())
-                && NumberUtils.isDigits(revisionV2.toString())) {
+        if (versionEndsWithRevision && numericIncreasingRevision) {
             v1 = ArrayUtils.add(v1, revisionV1);
             v2 = ArrayUtils.add(v2, revisionV2);
         }

--- a/communote/persistence/src/main/java/com/communote/server/core/bootstrap/ApplicationInitializer.java
+++ b/communote/persistence/src/main/java/com/communote/server/core/bootstrap/ApplicationInitializer.java
@@ -172,7 +172,7 @@ public class ApplicationInitializer {
         }
         String currentApplicationVersion = CommunoteRuntime.getInstance()
                 .getApplicationInformation().getBuildNumber();
-        VersionComparator versionComparator = new VersionComparator(true);
+        VersionComparator versionComparator = new VersionComparator(true, false);
         int versionComparison = versionComparator.compare(previousApplicationVersion,
                 currentApplicationVersion);
         if (versionComparison > 0) {

--- a/communote/persistence/src/test/java/com/communote/server/service/common/data/ApplicationVersionTest.java
+++ b/communote/persistence/src/test/java/com/communote/server/service/common/data/ApplicationVersionTest.java
@@ -16,7 +16,7 @@ public class ApplicationVersionTest {
     @Test
     public void testCompareVersions() {
         String version = "1";
-        VersionComparator revisionVersionComp = new VersionComparator(true);
+        VersionComparator revisionVersionComp = new VersionComparator(true, true);
         VersionComparator versionComp = new VersionComparator();
         for (int i = 0; i < RandomUtils.nextInt(10) + 5; i++) {
             version += "." + i;
@@ -34,7 +34,11 @@ public class ApplicationVersionTest {
         Assert.assertTrue(revisionVersionComp.compare("2.1.0", "2.1.0.0.0.0.0.0.1") < 0);
         Assert.assertTrue(revisionVersionComp.compare("2.1.1.11480", "2.1.9617") > 0); // KENMEI-4615
         Assert.assertTrue(revisionVersionComp.compare("2.1.0.abcde", "2.1.defgh") == 0);
+        Assert.assertTrue(revisionVersionComp.compare("3.0.1.012345", "3.0.1.0abcde") > 0);
+        
+        revisionVersionComp = new VersionComparator(true, false);
         Assert.assertEquals(revisionVersionComp.compare("3.0.1.012345", "3.0.1.0abcde"), 0); // KENMEI-6778
+        Assert.assertEquals(revisionVersionComp.compare("3.0.1.12345", "3.0.1.5678"), 0);
 
         // Without Revision
         Assert.assertTrue(versionComp.compare("1.1", "1.0.1") > 0); // KENMEI-4688


### PR DESCRIPTION
- VersionComparator supports versions with revisions and the revision can now be excluded from comparison
- ApplicationInitializer uses a VersionComparator which excludes the revision